### PR TITLE
Update version to 2.1.2 and enhance Windows compatibility for Python …

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,21 @@ That's it! Enjoy your ASCII aquarium! 🐠
 
 ## � Requirements
 
-- **Python 3.7+** - Works with Python 3.7 through 3.13
-- **Terminal** - Any terminal with color support
+- **Python 3.7+** - Works with Python 3.7 through 3.14+
+- **Terminal** - Any terminal with color support (minimum 40x15, recommended 80x24)
 - **Dependencies** - Automatically handled:
-  - `windows-curses` - Auto-installed on Windows only
+  - `windows-curses` - Auto-installed on Windows (Python < 3.13)
   - `curses` - Built-in on Linux/macOS
+
+### Python 3.13+ Support
+
+For Python 3.13+ on Windows, you may need to install `windows-curses` manually:
+
+```bash
+pip install windows-curses
+```
+
+If you encounter issues, consider using Python 3.12 or earlier for the most stable experience.
 
 ## 🌍 Platform Support
 

--- a/asciiquarium/__version__.py
+++ b/asciiquarium/__version__.py
@@ -1,6 +1,6 @@
 """Version information for asciiquarium"""
 
-__version__ = "2.1.0"
+__version__ = "2.1.2"
 __author__ = "Mohammad Abu Mattar"
 __email__ = "info@mkabumattar.com"
 __license__ = "GPL-3.0-or-later"

--- a/asciiquarium/animation.py
+++ b/asciiquarium/animation.py
@@ -1,6 +1,23 @@
-import curses
+import sys
 import time
 from typing import Any, Callable, Dict, List, Optional
+
+# Handle curses import for different Python versions and platforms
+try:
+    import curses
+except ImportError:
+    # On Windows with Python 3.13+, curses might not be available
+    # This will be caught and handled gracefully
+    if sys.platform == "win32":
+        try:
+            import windows_curses as curses  # type: ignore
+        except ImportError:
+            raise ImportError(
+                "Curses support is not available. On Windows with Python 3.13+, "
+                "you may need to install windows-curses manually or use Python 3.12 or earlier."
+            )
+    else:
+        raise
 
 from .entity import Entity
 

--- a/asciiquarium/main.py
+++ b/asciiquarium/main.py
@@ -173,6 +173,16 @@ def main():
             return setup_aquarium(anim_instance, args.classic)
         
         anim.run(setup_with_mode)
+    except ImportError as e:
+        if "curses" in str(e).lower():
+            print(f"Error: {e}", file=sys.stderr)
+            if sys.version_info >= (3, 13) and platform.system() == "Windows":
+                print("\nFor Python 3.13+ on Windows, try:", file=sys.stderr)
+                print("  pip install windows-curses", file=sys.stderr)
+                print("  or use Python 3.12 or earlier", file=sys.stderr)
+            sys.exit(1)
+        else:
+            raise
     except KeyboardInterrupt:
         pass
     except Exception as e:
@@ -180,6 +190,11 @@ def main():
         sys.exit(1)
     finally:
         print("\nThanks for watching! 🐠🐟🦈")
+
+
+def cli_main():
+    """CLI entry point alias"""
+    main()
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asciiquarium"
-version = "2.1.1"
+version = "2.1.2"
 description = "An aquarium/sea animation in ASCII art for your terminal"
 readme = "README.md"
 requires-python = ">=3.7"
@@ -26,11 +26,12 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Games/Entertainment",
 ]
 
 dependencies = [
-    "windows-curses>=2.4.1; sys_platform == 'win32'",
+    "windows-curses>=2.4.1; sys_platform == 'win32' and python_version < '3.13'",
     "typing-extensions>=4.0.0; python_version < '3.8'"
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -14,11 +14,11 @@ resolution-markers = [
 
 [[package]]
 name = "asciiquarium"
-version = "2.1.0"
+version = "2.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "typing-extensions", version = "4.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.8'" },
-    { name = "windows-curses", marker = "sys_platform == 'win32'" },
+    { name = "windows-curses", marker = "python_full_version < '3.13' and sys_platform == 'win32'" },
 ]
 
 [package.optional-dependencies]
@@ -41,7 +41,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "typing-extensions", marker = "python_full_version < '3.8'", specifier = ">=4.0.0" },
-    { name = "windows-curses", marker = "sys_platform == 'win32'", specifier = ">=2.4.1" },
+    { name = "windows-curses", marker = "python_full_version < '3.13' and sys_platform == 'win32'", specifier = ">=2.4.1" },
 ]
 provides-extras = ["dev"]
 


### PR DESCRIPTION
…3.13+

---

This pull request adds support for Python 3.14 and improves compatibility with Python 3.13+ on Windows, including clearer instructions and more robust error handling for terminal/curses support. It also updates versioning and documentation to reflect these changes.

### Python 3.13+ and 3.14 compatibility improvements

* Updated `README.md` to clarify terminal size requirements and provide instructions for installing `windows-curses` manually on Python 3.13+ for Windows users. Also added a note recommending Python 3.12 or earlier for best stability.
* Improved `asciiquarium/animation.py` to handle the import of `curses` more gracefully, especially on Windows with Python 3.13+, and provide a clear error message if support is missing.
* Enhanced error handling in `asciiquarium/main.py` to print helpful messages and installation instructions when `curses` is not available on Python 3.13+ for Windows.

### Packaging and metadata updates

* Updated project version to `2.1.2` in both `pyproject.toml` and `asciiquarium/__version__.py`. Added Python 3.14 to supported classifiers and restricted `windows-curses` dependency to Python < 3.13 on Windows. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7) [[2]](diffhunk://#diff-3b62e3f7f4cd02d2984dcbd6ca297a3475108935bb8c76157ceea999b8fd476eL3-R3) [[3]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R29-R34)

### CLI improvements

* Added a `cli_main()` function to `asciiquarium/main.py` as an alias for the main entry point, improving CLI integration.